### PR TITLE
Bind assembly goal to 'mvn package' command

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,5 +44,5 @@ Digital Scholarship in the Humanities, Vol. 30 Iss. 2, pp. 262–279, 2015.
 
 ## Compile
 
-* Execute `mvn package assembly:single`
+* Execute `mvn package`
 * Extension will be located into `target/`

--- a/pom.xml
+++ b/pom.xml
@@ -25,6 +25,15 @@
       <plugin>
         <artifactId>maven-assembly-plugin</artifactId>
         <version>3.3.0</version>
+        <executions>
+          <execution>
+            <id>assemble</id>
+            <goals>
+              <goal>single</goal>
+            </goals>
+            <phase>package</phase>
+          </execution>
+        </executions>
         <configuration>
           <appendAssemblyId>false</appendAssemblyId>
           <descriptors>


### PR DESCRIPTION
To make development a bit easier (really minor change, but I just found myself doing `mvn package` and not finding the output `.zip` file).